### PR TITLE
Raise Faraday::ConnectionFailed for OpenTimeout errors

### DIFF
--- a/lib/faraday/adapter/net_http_persistent.rb
+++ b/lib/faraday/adapter/net_http_persistent.rb
@@ -25,9 +25,7 @@ module Faraday
       ]
 
       exceptions << ::OpenSSL::SSL::SSLError if defined?(::OpenSSL::SSL::SSLError)
-      # TODO (breaking): Enable this to make it consistent with net_http adapter.
-      #   See https://github.com/lostisland/faraday/issues/718#issuecomment-344549382
-      # exceptions << ::Net::OpenTimeout if defined?(::Net::OpenTimeout)
+      exceptions << ::Net::OpenTimeout if defined?(::Net::OpenTimeout)
 
       NET_HTTP_EXCEPTIONS = exceptions.freeze
 


### PR DESCRIPTION
Part of https://github.com/splitwise/enrollment/issues/5196

Builds are failing due to these shared examples coming from Faraday, which explicitly treat NetHttp adapters differently than others:
https://github.com/lostisland/faraday/blob/ea30bd0b543882f1cf26e75ac4e46e0705fa7e68/spec/support/shared_examples/request_method.rb#L116
https://github.com/lostisland/faraday/blob/ea30bd0b543882f1cf26e75ac4e46e0705fa7e68/spec/support/shared_examples/request_method.rb#L125